### PR TITLE
Block users from accessing the nodes in language they don't have perm

### DIFF
--- a/language_access.module
+++ b/language_access.module
@@ -1,4 +1,7 @@
 <?php
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_language_switch_links_alter()
@@ -13,4 +16,19 @@ function language_access_language_switch_links_alter(&$links, $type, $path) {
       if (isset($links[$id])) unset($links[$id]);
     }
   }
+}
+
+/**
+ * Implements hook_node_access().
+ */
+function language_access_node_access(NodeInterface $node, $op, AccountInterface $account) {
+  if ($op == 'view') {
+    /** @var Drupal\Core\Language\Language $language */
+    $language = $node->language();
+    if (!$account->hasPermission('access language ' . $language->getId())) {
+      return AccessResult::forbidden();
+    }
+  }
+
+  return AccessResult::neutral();
 }


### PR DESCRIPTION
I have tried using this module for a following scenario:

We have a website with three languages but we don't want anonymous users to access the languages which are not released yet. When caching was enabled, it was still possible to access the other languages, so I've added a node_access implementation to stop people from accessing those pages.